### PR TITLE
Synthetic spectra fixes

### DIFF
--- a/generate_synthetic_spectra.py
+++ b/generate_synthetic_spectra.py
@@ -421,7 +421,7 @@ if __name__ == '__main__':
     spectra_parameters_class.spectra_parameters_df["specname"] = spectra_parameters_class.spectra_parameters_df["specname"].apply(lambda x: f"{x}.spec")
 
     # delete any specname columns that are not in the results
-    spectra_parameters_class.spectra_parameters_df = spectra_parameters_class.spectra_parameters_df[spectra_parameters_class.spectra_parameters_df["specname"].isin(results[:, 0])]
+    spectra_parameters_class.spectra_parameters_df = spectra_parameters_class.spectra_parameters_df[spectra_parameters_class.spectra_parameters_df["specname"].isin(results)]
 
     # if vmic is not in the columns, add it by calculating using the function calculate_vturb
     if "vmic" not in spectra_parameters_class.spectra_parameters_df.columns:

--- a/generate_synthetic_spectra.py
+++ b/generate_synthetic_spectra.py
@@ -397,8 +397,8 @@ if __name__ == '__main__':
     # if column Fe_Fe is present, then rename it to A(Fe)
     if "Fe_Fe" in temp_df.columns:
         temp_df.rename(columns={"Fe_Fe": "A(Fe)"}, inplace=True)
-    # and change its value by adding FeH and solar abundance of Fe
-    temp_df["A(Fe)"] = temp_df["A(Fe)"] + temp_df["feh"] + periodic_table["Fe"]
+        # and change its value by adding FeH and solar abundance of Fe
+        temp_df["A(Fe)"] = temp_df["A(Fe)"] + temp_df["feh"] + periodic_table["Fe"]
 
     # save the spectra parameters
     temp_df.to_csv(os.path.join(output_dir, "spectra_parameters_temp.csv"), index=False)
@@ -438,8 +438,8 @@ if __name__ == '__main__':
     # if column Fe_Fe is present, then rename it to A(Fe)
     if "Fe_Fe" in spectra_parameters_class.spectra_parameters_df.columns:
         spectra_parameters_class.spectra_parameters_df.rename(columns={"Fe_Fe": "A(Fe)"}, inplace=True)
-    # and change its value by adding FeH and solar abundance of Fe
-    spectra_parameters_class.spectra_parameters_df["A(Fe)"] = spectra_parameters_class.spectra_parameters_df["A(Fe)"] + spectra_parameters_class.spectra_parameters_df["feh"] + periodic_table["Fe"]
+        # and change its value by adding FeH and solar abundance of Fe
+        spectra_parameters_class.spectra_parameters_df["A(Fe)"] = spectra_parameters_class.spectra_parameters_df["A(Fe)"] + spectra_parameters_class.spectra_parameters_df["feh"] + periodic_table["Fe"]
 
     # save the spectra parameters 
     spectra_parameters_class.spectra_parameters_df.to_csv(os.path.join(output_dir, "spectra_parameters.csv"), index=False)

--- a/generate_synthetic_spectra.py
+++ b/generate_synthetic_spectra.py
@@ -17,7 +17,7 @@ import os
 from scripts.run_wrapper import run_and_save_wrapper
 from time import perf_counter
 from scripts.loading_configs import SpectraParameters
-from scripts.solar_abundances import periodic_table
+from scripts.solar_abundances import periodic_table, solar_abundances
 from scripts.auxiliary_functions import calculate_vturb
 
 class SyntheticSpectraConfig:
@@ -398,7 +398,7 @@ if __name__ == '__main__':
     if "Fe_Fe" in temp_df.columns:
         temp_df.rename(columns={"Fe_Fe": "A(Fe)"}, inplace=True)
         # and change its value by adding FeH and solar abundance of Fe
-        temp_df["A(Fe)"] = temp_df["A(Fe)"] + temp_df["feh"] + periodic_table["Fe"]
+        temp_df["A(Fe)"] = temp_df["A(Fe)"] + temp_df["feh"] + solar_abundances["Fe"]
 
     # save the spectra parameters
     temp_df.to_csv(os.path.join(output_dir, "spectra_parameters_temp.csv"), index=False)
@@ -439,7 +439,7 @@ if __name__ == '__main__':
     if "Fe_Fe" in spectra_parameters_class.spectra_parameters_df.columns:
         spectra_parameters_class.spectra_parameters_df.rename(columns={"Fe_Fe": "A(Fe)"}, inplace=True)
         # and change its value by adding FeH and solar abundance of Fe
-        spectra_parameters_class.spectra_parameters_df["A(Fe)"] = spectra_parameters_class.spectra_parameters_df["A(Fe)"] + spectra_parameters_class.spectra_parameters_df["feh"] + periodic_table["Fe"]
+        spectra_parameters_class.spectra_parameters_df["A(Fe)"] = spectra_parameters_class.spectra_parameters_df["A(Fe)"] + spectra_parameters_class.spectra_parameters_df["feh"] + solar_abundances["Fe"]
 
     # save the spectra parameters 
     spectra_parameters_class.spectra_parameters_df.to_csv(os.path.join(output_dir, "spectra_parameters.csv"), index=False)

--- a/scripts/run_wrapper.py
+++ b/scripts/run_wrapper.py
@@ -147,13 +147,21 @@ def run_and_save_wrapper(tsfitpy_pickled_configuration_path, teff, logg, met, lm
         print("#resolution: {}".format(resolution), file=f)
         print("#rotation: {}".format(rotation), file=f)
         print("#nlte_flag: {}".format(nlte_flag), file=f)
-        for key, value in abundances_dict.items():
-            if key != "Fe":
-                print(f"#[{key}/Fe]={value}", file=f)
+
+        # get which elements are in NLTE using ts_config["model_atom_file"]
+        nlte_elements = ts_config["model_atom_file"].keys()
+
+        for element, value in abundances_dict.items():
+            if element in nlte_elements:
+                nlte_flag = "NLTE"
+            else:
+                nlte_flag = "LTE"
+            if element != "Fe":
+                print(f"#[{element}/Fe]={value} {nlte_flag}", file=f)
             else:
                 # if Fe, it is given as weird Fe/Fe way, which can be fixed back by:
                 # xfe + feh + A(X)_sun = A(X)_star
-                print(f"#A({key})={value + met + solar_abundances['Fe']}", file=f)
+                print(f"#A({element})={value + met + solar_abundances['Fe']} {nlte_flag}", file=f)
         print("#", file=f)
 
         if save_unnormalised_spectra:
@@ -165,3 +173,6 @@ def run_and_save_wrapper(tsfitpy_pickled_configuration_path, teff, logg, met, lm
             for i in range(len(wave_mod)):
                 print("{}  {}".format(wave_mod[i], flux_norm_mod[i]), file=f)
         f.close()
+        return spectrum_name
+    else:
+        return ""

--- a/scripts/run_wrapper.py
+++ b/scripts/run_wrapper.py
@@ -30,8 +30,7 @@ def run_wrapper(ts_config, spectrum_name, teff, logg, met, lmin, lmax, ldelta, n
 
     # need to convert abundances_dict from X/Fe to X/H
     for key, value in abundances_dict_xh.items():
-        if key != "Fe":
-            abundances_dict_xh[key] = value + met
+        abundances_dict_xh[key] = value + met
 
     if not os.path.exists(temp_directory):
         os.makedirs(temp_directory)

--- a/scripts/run_wrapper.py
+++ b/scripts/run_wrapper.py
@@ -142,6 +142,8 @@ def run_and_save_wrapper(tsfitpy_pickled_configuration_path, teff, logg, met, lm
         print("#teff: {}".format(teff), file=f)
         print("#logg: {}".format(logg), file=f)
         print("#[Fe/H]: {}".format(met), file=f)
+        if vturb is None:
+            vturb = calculate_vturb(teff, logg, met)
         print("#vmic: {}".format(vturb), file=f)
         print("#vmac: {}".format(macro), file=f)
         print("#resolution: {}".format(resolution), file=f)

--- a/scripts/run_wrapper.py
+++ b/scripts/run_wrapper.py
@@ -153,8 +153,11 @@ def run_and_save_wrapper(tsfitpy_pickled_configuration_path, teff, logg, met, lm
         nlte_elements = ts_config["model_atom_file"].keys()
 
         for element, value in abundances_dict.items():
-            if element in nlte_elements:
-                nlte_flag = "NLTE"
+            if nlte_flag:
+                if element in nlte_elements:
+                    nlte_flag = "NLTE"
+                else:
+                    nlte_flag = "LTE"
             else:
                 nlte_flag = "LTE"
             if element != "Fe":


### PR DESCRIPTION
- A(Fe) is now correctly passed even alongside FeH. In that case FeH is used for choice of model atmosphere and abundance scaling, and A(Fe) for the absolute abundance of Fe
- Only saves .csv file with spectra that finish computing
- Saves .csv before computing spectra in case it crashes - at least some kind of parameters are saved
- Saves used vmic if no vmic is passed
- Specifies which element was NLTE or LTE in the header